### PR TITLE
8 middlewareによるアクセス制限

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Post;
+use Illuminate\Support\Facades\Gate;
 
 use function PHPSTORM_META\map;
 
@@ -15,6 +16,7 @@ class PostController extends Controller
     }
 
     public function store(Request $request) {
+        Gate::authorize('test');
         $validated = $request->validate([
             'title' => 'required|max:20',
             'body' => 'required|max:400',

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,7 +2,8 @@
 
 namespace App\Providers;
 
-// use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Gate;
+use App\Models\User;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -21,6 +22,13 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // Gateを定義
+        Gate::define('test', function (User $user) {
+            if($user->id === 1) {
+                return true;
+            }
+
+            return false;
+        });
     }
 }

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -16,6 +16,10 @@
         </style>
     </head>
     <body class="antialiased">
+        @can('test')
+            あなたはID1のユーザーです。Gateは有効です。
+        @endcan
+
         @auth
             @for ($i = 0; $i <10; $i++)
                 {{ $i }},

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,7 +18,9 @@ use App\Http\Controllers\PostController;
 
 Route::get('/', function () {
     return view('welcome');
-});
+})
+// ->middleware('can:test')
+; //testゲートを適用
 
 Route::get('/dashboard', function () {
     return view('dashboard');
@@ -31,8 +33,12 @@ Route::middleware('auth')->group(function () {
 });
 
 Route::get('/test', [TestController::class, 'test'])->name('test');
-Route::get('post/create', [PostController::class, 'create'])->name('create');
 Route::post('post', [PostController::class, 'store'])->name('post.store');
-Route::get('post', [PostController::class, 'index']);
+// Route::middleware(['auth', 'can:admin'])->group(function() {
+    Route::get('post', [PostController::class, 'index']);
+    Route::get('post/create', [PostController::class, 'create'])->name('create');
+// });
+
+
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Chapter8　middlewareによるアクセス制限　を確認しました。

- トップページを`middleware`により管理者のみアクセス可能にする
- Gateを設定し、複数の場所で動作や表示を制限
  - Gateの設定
  - `routes.php`でアクセス制限
  - `view`でアクセス制限
  - `Controller`でアクセス制限